### PR TITLE
Week5 feat#45

### DIFF
--- a/public/data/daily_rank.json
+++ b/public/data/daily_rank.json
@@ -1,0 +1,467 @@
+[
+  {
+    "day": 20240620,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240621,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240622,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240623,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240624,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240625,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240626,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240627,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240628,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240629,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240630,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240701,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240702,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "KT" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240703,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240704,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240705,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240706,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240707,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240708,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240709,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240710,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240711,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240712,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240713,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240714,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240715,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240716,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240717,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "롯데" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240718,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240719,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  },
+  {
+    "day": 20240720,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "KT" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  }
+]

--- a/public/data/year_rank.json
+++ b/public/data/year_rank.json
@@ -236,7 +236,7 @@
     "year": 2000,
     "data": [
       { "rank": 1, "team": "현대" },
-      { "rank": 2, "team": "롯데" },
+      { "rank": 2, "team": "두산" },
       { "rank": 3, "team": "삼성" },
       { "rank": 4, "team": "LG" },
       { "rank": 5, "team": "롯데" },

--- a/public/data/year_rank.json
+++ b/public/data/year_rank.json
@@ -1,0 +1,567 @@
+[
+  {
+    "year": 1982,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "KIA" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1983,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "현대" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 1984,
+    "data": [
+      { "rank": 1, "team": "롯데" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1985,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "롯데" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "LG" },
+      { "rank": 6, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1986,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "현대" },
+      { "rank": 7, "team": "한화" }
+    ]
+  },
+  {
+    "year": 1987,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "롯데" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "LG" },
+      { "rank": 6, "team": "한화" },
+      { "rank": 7, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1988,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "롯데" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1989,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "현대" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 1989,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "현대" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 1990,
+    "data": [
+      { "rank": 1, "team": "LG" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 4, "team": "한화" },
+      { "rank": 5, "team": "현대" },
+      { "rank": 6, "team": "롯데" },
+      { "rank": 7, "team": "두산" }
+    ]
+  },
+  {
+    "year": 1991,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "롯데" },
+      { "rank": 5, "team": "현대" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 6, "team": "쌍방울" },
+      { "rank": 8, "team": "두산" }
+    ]
+  },
+  {
+    "year": 1992,
+    "data": [
+      { "rank": 1, "team": "롯데" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "현대" },
+      { "rank": 7, "team": "LG" },
+      { "rank": 8, "team": "쌍방울" }
+    ]
+  },
+  {
+    "year": 1993,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "한화" },
+      { "rank": 6, "team": "롯데" },
+      { "rank": 7, "team": "쌍방울" },
+      { "rank": 8, "team": "현대" }
+    ]
+  },
+  {
+    "year": 1994,
+    "data": [
+      { "rank": 1, "team": "LG" },
+      { "rank": 2, "team": "현대" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 3, "team": "한화" },
+      { "rank": 5, "team": "삼성" },
+      { "rank": 6, "team": "롯데" },
+      { "rank": 7, "team": "두산" },
+      { "rank": 8, "team": "쌍방울" }
+    ]
+  },
+  {
+    "year": 1995,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "롯데" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "KIA" },
+      { "rank": 5, "team": "삼성" },
+      { "rank": 6, "team": "한화" },
+      { "rank": 7, "team": "현대" },
+      { "rank": 8, "team": "쌍방울" }
+    ]
+  },
+  {
+    "year": 1996,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "현대" },
+      { "rank": 3, "team": "쌍방울" },
+      { "rank": 4, "team": "한화" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "삼성" },
+      { "rank": 7, "team": "LG" },
+      { "rank": 8, "team": "두산" }
+    ]
+  },
+  {
+    "year": 1997,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "쌍방울" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "현대" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 1998,
+    "data": [
+      { "rank": 1, "team": "현대" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "두산" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "쌍방울" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 1999,
+    "data": [
+      { "rank": 1, "team": "한화" },
+      { "rank": 2, "team": "롯데" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "현대" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "KIA" },
+      { "rank": 8, "team": "쌍방울" }
+    ]
+  },
+  {
+    "year": 2000,
+    "data": [
+      { "rank": 1, "team": "현대" },
+      { "rank": 2, "team": "롯데" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "KIA" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "SSG" }
+    ]
+  },
+  {
+    "year": 2001,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "현대" },
+      { "rank": 4, "team": "한화" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "SSG" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 2002,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "LG" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 4, "team": "현대" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "SSG" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 2003,
+    "data": [
+      { "rank": 1, "team": "현대" },
+      { "rank": 2, "team": "SSG" },
+      { "rank": 3, "team": "KIA" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "한화" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "두산" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 2004,
+    "data": [
+      { "rank": 1, "team": "현대" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "KIA" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 2005,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "SSG" },
+      { "rank": 4, "team": "한화" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "현대" },
+      { "rank": 8, "team": "KIA" }
+    ]
+  },
+  {
+    "year": 2006,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "한화" },
+      { "rank": 3, "team": "현대" },
+      { "rank": 4, "team": "KIA" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "SSG" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "LG" }
+    ]
+  },
+  {
+    "year": 2007,
+    "data": [
+      { "rank": 1, "team": "SSG" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "한화" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "LG" },
+      { "rank": 6, "team": "현대" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "KIA" }
+    ]
+  },
+  {
+    "year": 2008,
+    "data": [
+      { "rank": 1, "team": "SSG" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "롯데" },
+      { "rank": 4, "team": "삼성" },
+      { "rank": 5, "team": "한화" },
+      { "rank": 6, "team": "KIA" },
+      { "rank": 7, "team": "키움" },
+      { "rank": 8, "team": "LG" }
+    ]
+  },
+  {
+    "year": 2009,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "SSG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "롯데" },
+      { "rank": 5, "team": "삼성" },
+      { "rank": 6, "team": "키움" },
+      { "rank": 7, "team": "LG" },
+      { "rank": 8, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2010,
+    "data": [
+      { "rank": 1, "team": "SSG" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "롯데" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "키움" },
+      { "rank": 8, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2011,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "SSG" },
+      { "rank": 3, "team": "롯데" },
+      { "rank": 4, "team": "KIA" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 6, "team": "한화" },
+      { "rank": 8, "team": "키움" }
+    ]
+  },
+  {
+    "year": 2012,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "SSG" },
+      { "rank": 3, "team": "두산" },
+      { "rank": 4, "team": "롯데" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "키움" },
+      { "rank": 7, "team": "LG" },
+      { "rank": 8, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2013,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "키움" },
+      { "rank": 5, "team": "롯데" },
+      { "rank": 6, "team": "SSG" },
+      { "rank": 7, "team": "NC" },
+      { "rank": 8, "team": "KIA" },
+      { "rank": 9, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2014,
+    "data": [
+      { "rank": 1, "team": "삼성" },
+      { "rank": 2, "team": "키움" },
+      { "rank": 3, "team": "NC" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "두산" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "KIA" },
+      { "rank": 9, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2015,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "삼성" },
+      { "rank": 3, "team": "NC" },
+      { "rank": 4, "team": "키움" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "한화" },
+      { "rank": 7, "team": "KIA" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "LG" },
+      { "rank": 10, "team": "KT" }
+    ]
+  },
+  {
+    "year": 2016,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "NC" },
+      { "rank": 3, "team": "키움" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "SSG" },
+      { "rank": 7, "team": "한화" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "삼성" },
+      { "rank": 10, "team": "KT" }
+    ]
+  },
+  {
+    "year": 2017,
+    "data": [
+      { "rank": 1, "team": "KIA" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "롯데" },
+      { "rank": 4, "team": "NC" },
+      { "rank": 5, "team": "SSG" },
+      { "rank": 6, "team": "LG" },
+      { "rank": 7, "team": "키움" },
+      { "rank": 8, "team": "한화" },
+      { "rank": 9, "team": "삼성" },
+      { "rank": 10, "team": "KT" }
+    ]
+  },
+  {
+    "year": 2018,
+    "data": [
+      { "rank": 1, "team": "SSG" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "한화" },
+      { "rank": 4, "team": "키움" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "삼성" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "LG" },
+      { "rank": 9, "team": "KT" },
+      { "rank": 10, "team": "NC" }
+    ]
+  },
+  {
+    "year": 2019,
+    "data": [
+      { "rank": 1, "team": "두산" },
+      { "rank": 2, "team": "키움" },
+      { "rank": 3, "team": "SSG" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "NC" },
+      { "rank": 6, "team": "KT" },
+      { "rank": 7, "team": "KIA" },
+      { "rank": 8, "team": "삼성" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "롯데" }
+    ]
+  },
+  {
+    "year": 2020,
+    "data": [
+      { "rank": 1, "team": "NC" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "KT" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "키움" },
+      { "rank": 6, "team": "KIA" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "삼성" },
+      { "rank": 9, "team": "SSG" },
+      { "rank": 10, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2021,
+    "data": [
+      { "rank": 1, "team": "KT" },
+      { "rank": 2, "team": "두산" },
+      { "rank": 3, "team": "삼성" },
+      { "rank": 4, "team": "LG" },
+      { "rank": 5, "team": "키움" },
+      { "rank": 6, "team": "SSG" },
+      { "rank": 7, "team": "NC" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "KIA" },
+      { "rank": 10, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2022,
+    "data": [
+      { "rank": 1, "team": "SSG" },
+      { "rank": 2, "team": "키움" },
+      { "rank": 3, "team": "LG" },
+      { "rank": 4, "team": "KT" },
+      { "rank": 5, "team": "KIA" },
+      { "rank": 6, "team": "NC" },
+      { "rank": 7, "team": "삼성" },
+      { "rank": 8, "team": "롯데" },
+      { "rank": 9, "team": "두산" },
+      { "rank": 10, "team": "한화" }
+    ]
+  },
+  {
+    "year": 2023,
+    "data": [
+      { "rank": 1, "team": "LG" },
+      { "rank": 2, "team": "KT" },
+      { "rank": 3, "team": "SSG" },
+      { "rank": 4, "team": "NC" },
+      { "rank": 5, "team": "두산" },
+      { "rank": 6, "team": "KIA" },
+      { "rank": 7, "team": "롯데" },
+      { "rank": 8, "team": "삼성" },
+      { "rank": 9, "team": "한화" },
+      { "rank": 10, "team": "키움" }
+    ]
+  }
+]

--- a/src/app/(main)/ranking/ai/page.tsx
+++ b/src/app/(main)/ranking/ai/page.tsx
@@ -70,9 +70,9 @@ export default async function RankingAi() {
 
   return (
     <>
-      <div className="bg-[url('/images/mainBg.png')] bg-cover relative overflow-hidden h-screen">
-        <div className="w-3/4 mx-auto text-white pb-16 h-screen">
-          {dayOfWeek === 0 || dayOfWeek === 1 ? (
+      <div className="flex flex-1 bg-[url('/images/mainBg.png')] bg-cover relative items-center overflow-hidden">
+        <div className="w-3/4 mx-auto text-white">
+          {dayOfWeek === 1 ? (
             <div className="flex flex-col justify-center items-center font-semibold text-xl gap-4 h-3/4 max-sm:gap-0">
               <div className="flex justify-center h-64 mb-4 max-sm:h-1/4">
                 <Image
@@ -123,7 +123,7 @@ export default async function RankingAi() {
                   homeScore={`${winPercent}%`}
                   awayScore={`${100 - winPercent}%`}
                 />
-                <div className="flex w-full justify-center items-center gap-5">
+                <div className="flex w-full justify-center items-center gap-5 pb-16">
                   <p className="w-full text-end max-sm:text-sm">{pitcher[0]}</p>
                   <p className="whitespace-nowrap">선발 투수</p>
                   <p className="w-full max-sm:text-sm">{pitcher[1]}</p>

--- a/src/app/(main)/ranking/ai/page.tsx
+++ b/src/app/(main)/ranking/ai/page.tsx
@@ -23,7 +23,8 @@ export default async function RankingAi() {
   const month = new Date().getMonth() + 1;
   const yearmonth = year + '0' + month;
 
-  const dayOfWeek = new Date().getDay();
+  // const dayOfWeek = new Date().getDay();
+  const dayOfWeek = 1;
 
   //선발투수 정보 API
   const day_num: number = julyScheduleJSON[today];
@@ -70,17 +71,17 @@ export default async function RankingAi() {
 
   return (
     <>
-      <div className="bg-[url('/images/mainBg.png')] bg-cover relative overflow-hidden">
-        <div className="w-3/4 mx-auto text-white pb-16">
+      <div className="bg-[url('/images/mainBg.png')] bg-cover relative overflow-hidden h-screen">
+        <div className="w-3/4 mx-auto text-white pb-16 h-screen">
           {dayOfWeek === 0 || dayOfWeek === 1 ? (
-            <div className="flex flex-col h-screen justify-center items-center font-semibold text-xl gap-4">
-              <div className="flex justify-center h-64 mb-4">
+            <div className="flex flex-col justify-center items-center font-semibold text-xl gap-4 h-3/4 max-sm:gap-0">
+              <div className="flex justify-center h-64 mb-4 max-sm:h-1/4">
                 <Image
                   src="/svgs/newsMascot/ddory.svg"
                   alt="ticket"
                   width={0}
                   height={0}
-                  className="w-auto h-[100%]"
+                  className="w-auto h-[100%] "
                 />
                 <Image
                   src="/svgs/newsMascot/vic.svg"

--- a/src/app/(main)/ranking/ai/page.tsx
+++ b/src/app/(main)/ranking/ai/page.tsx
@@ -23,8 +23,7 @@ export default async function RankingAi() {
   const month = new Date().getMonth() + 1;
   const yearmonth = year + '0' + month;
 
-  // const dayOfWeek = new Date().getDay();
-  const dayOfWeek = 1;
+  const dayOfWeek = new Date().getDay();
 
   //선발투수 정보 API
   const day_num: number = julyScheduleJSON[today];

--- a/src/app/(main)/ranking/ai/page.tsx
+++ b/src/app/(main)/ranking/ai/page.tsx
@@ -3,6 +3,7 @@ import MatchTeam from '@/components/ranking/MatchTeam';
 import dateFormat from '@/utils/dateFormat';
 import winlossData from '#/data/winlossdata.json';
 import july_schedule from '#/data/july_schedule.json';
+import Image from 'next/image';
 
 import {
   TGameData,
@@ -22,11 +23,14 @@ export default async function RankingAi() {
   const month = new Date().getMonth() + 1;
   const yearmonth = year + '0' + month;
 
+  const dayOfWeek = new Date().getDay();
+
   //선발투수 정보 API
   const day_num: number = julyScheduleJSON[today];
 
   const pitcherRes: Response = await fetch(
     `${process.env.BASE_URL}/api/startingPitcher?day_num=${day_num}`,
+    { cache: 'no-store' },
   );
   const pitcherData: TPitcherData = await pitcherRes.json();
 
@@ -67,41 +71,66 @@ export default async function RankingAi() {
   return (
     <>
       <div className="bg-[url('/images/mainBg.png')] bg-cover relative overflow-hidden">
-        <div className="w-3/4 mx-auto text-white pb-16 ">
-          <div className="flex justify-center items-center gap-12 mt-24 max-sm:gap-6 max-sm:mt-10">
-            <MatchTeam teamName="KT" score={teamScore[0]} />
-            <div className="text-center">
-              <h1 className="text-7xl text-[#B3B3B3] font-extrabold max-sm:text-4xl">
-                VS
-              </h1>
-              <p className="mt-4 text-xl max-sm:text-base whitespace-nowrap">
-                {stadiums}
-              </p>
+        <div className="w-3/4 mx-auto text-white pb-16">
+          {dayOfWeek === 0 || dayOfWeek === 1 ? (
+            <div className="flex flex-col h-screen justify-center items-center font-semibold text-xl gap-4">
+              <div className="flex justify-center h-64 mb-4">
+                <Image
+                  src="/svgs/newsMascot/ddory.svg"
+                  alt="ticket"
+                  width={0}
+                  height={0}
+                  className="w-auto h-[100%]"
+                />
+                <Image
+                  src="/svgs/newsMascot/vic.svg"
+                  alt="ticket"
+                  width={0}
+                  height={0}
+                  className="w-auto h-[100%]"
+                />
+              </div>
+              <p>오늘은 경기가 없습니다</p>
+              <p>다음 경기를 기대해주세요!</p>
             </div>
-            <MatchTeam teamName={team[1]} score={teamScore[1]} />
-          </div>
-          <div className="flex flex-col justify-center items-center gap-8 mt-11">
-            <Graph
-              title="전체 승률"
-              homeScore={total.toFixed(3)}
-              awayScore={(1 - total).toFixed(3)}
-            />
-            <Graph
-              title="최근 승률"
-              homeScore={last.toFixed(3)}
-              awayScore={(1 - last).toFixed(3)}
-            />
-            <Graph
-              title="예상 승률"
-              homeScore={`${winPercent}%`}
-              awayScore={`${100 - winPercent}%`}
-            />
-            <div className="flex w-full justify-center items-center gap-5">
-              <p className="w-full text-end max-sm:text-sm">{pitcher[0]}</p>
-              <p className="whitespace-nowrap">선발 투수</p>
-              <p className="w-full max-sm:text-sm">{pitcher[1]}</p>
-            </div>
-          </div>
+          ) : (
+            <>
+              <div className="flex justify-center items-center gap-12 mt-24 max-sm:gap-6 max-sm:mt-10">
+                <MatchTeam teamName="KT" score={teamScore[0]} />
+                <div className="text-center">
+                  <h1 className="text-7xl text-[#B3B3B3] font-extrabold max-sm:text-4xl">
+                    VS
+                  </h1>
+                  <p className="mt-4 text-xl max-sm:text-base whitespace-nowrap">
+                    {stadiums}
+                  </p>
+                </div>
+                <MatchTeam teamName={team[1]} score={teamScore[1]} />
+              </div>
+              <div className="flex flex-col justify-center items-center gap-8 mt-11">
+                <Graph
+                  title="전체 승률"
+                  homeScore={total.toFixed(3)}
+                  awayScore={(1 - total).toFixed(3)}
+                />
+                <Graph
+                  title="최근 승률"
+                  homeScore={last.toFixed(3)}
+                  awayScore={(1 - last).toFixed(3)}
+                />
+                <Graph
+                  title="예상 승률"
+                  homeScore={`${winPercent}%`}
+                  awayScore={`${100 - winPercent}%`}
+                />
+                <div className="flex w-full justify-center items-center gap-5">
+                  <p className="w-full text-end max-sm:text-sm">{pitcher[0]}</p>
+                  <p className="whitespace-nowrap">선발 투수</p>
+                  <p className="w-full max-sm:text-sm">{pitcher[1]}</p>
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </>

--- a/src/app/(main)/ranking/daily/page.tsx
+++ b/src/app/(main)/ranking/daily/page.tsx
@@ -1,7 +1,18 @@
-import Calendar from '@/components/ranking/Calendar/Calendar';
+'use client';
+
+import DateRangePicker from '@/components/ranking/Calendar/DateRangePicker';
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
 
 export default function RankingDaily() {
+  const [startDate, setStartDate] = useState<Date | undefined>(undefined);
+  const [endDate, setEndDate] = useState<Date | undefined>(undefined);
+
+  const handleDateChange = (start: Date | null, end: Date | null) => {
+    setStartDate(start || undefined);
+    setEndDate(end || undefined);
+  };
+
   const Chart = dynamic(() => import('@/components/ranking/Chart'), {
     ssr: false,
   });
@@ -11,13 +22,18 @@ export default function RankingDaily() {
       <div className="w-3/4 mx-auto text-white pb-16">
         <div className="h-8 mt-[51px] text-lg max-sm:text-base border-l-4 border-red-100 flex items-center max-sm:flex-col max-sm:items-start">
           <p className="ml-3.5 max-sm:mb-3">비교 분석 구간:</p>
-          <Calendar />
+          <DateRangePicker onDateChange={handleDateChange} />
         </div>
         <p className="my-4 ml-4 text-sm max-sm:my-12">
           * 기간 검색은 30일 이내
         </p>
         <div className="overflow-x-auto">
-          <Chart title="일자별 순위 그래프" />
+          <Chart
+            title="일자별 순위 그래프"
+            startDate={startDate}
+            endDate={endDate}
+            page="daily"
+          />
         </div>
       </div>
     </>

--- a/src/app/(main)/ranking/layout.tsx
+++ b/src/app/(main)/ranking/layout.tsx
@@ -7,7 +7,7 @@ export default function RankingLayout({
 }) {
   return (
     <>
-      <div className="min-h-screen bg-black">
+      <div className="flex flex-col min-h-screen bg-black">
         <Banner />
         {children}
       </div>

--- a/src/app/(main)/ranking/year/page.tsx
+++ b/src/app/(main)/ranking/year/page.tsx
@@ -9,7 +9,7 @@ export default function RankingYear() {
     <>
       <div className="w-3/4 mx-auto text-white pb-16 mt-8">
         <div className="overflow-x-auto">
-          <Chart title="년도별 순위 그래프" />
+          <Chart title="년도별 순위 그래프" page="year" />
         </div>
       </div>
     </>

--- a/src/components/ranking/Banner.tsx
+++ b/src/components/ranking/Banner.tsx
@@ -28,7 +28,7 @@ export default function Banner() {
 
   return (
     <>
-      <div className="pt-20">
+      <div className="flex-none pt-20">
         <div className="bg-[url('/images/bannerBg.png')] h-[252px] w-full flex flex-col items-center text-center text-white">
           <div>
             <h1 className="mt-14 text-5xl max-sm:text-3xl font-extrabold">

--- a/src/components/ranking/Calendar/DateRangePicker.tsx
+++ b/src/components/ranking/Calendar/DateRangePicker.tsx
@@ -5,18 +5,25 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import '@/components/ranking/Calendar/Calendar.css';
 
-export default function DateRangePicker() {
+type DateRangePickerProps = {
+  onDateChange: (start: Date | null, end: Date | null) => void;
+};
+
+export default function DateRangePicker({
+  onDateChange,
+}: DateRangePickerProps) {
   const today = new Date();
   const thirtyDaysAgo = new Date(today);
   thirtyDaysAgo.setDate(today.getDate() - 30);
 
-  const [startDate, setStartDate] = useState<Date | undefined>(thirtyDaysAgo);
-  const [endDate, setEndDate] = useState<Date | undefined>(today);
+  const [startDate, setStartDate] = useState<Date | null>(thirtyDaysAgo);
+  const [endDate, setEndDate] = useState<Date | null>(today);
 
   const handleDateChange = (dates: [Date | null, Date | null]) => {
     const [start, end] = dates;
-    setStartDate(start || undefined);
-    setEndDate(end || undefined);
+    setStartDate(start);
+    setEndDate(end);
+    onDateChange(start, end);
   };
 
   return (

--- a/src/components/ranking/Calendar/DateRangePicker.tsx
+++ b/src/components/ranking/Calendar/DateRangePicker.tsx
@@ -16,13 +16,13 @@ export default function DateRangePicker({
   const thirtyDaysAgo = new Date(today);
   thirtyDaysAgo.setDate(today.getDate() - 30);
 
-  const [startDate, setStartDate] = useState<Date | null>(thirtyDaysAgo);
-  const [endDate, setEndDate] = useState<Date | null>(today);
+  const [startDate, setStartDate] = useState<Date | undefined>(thirtyDaysAgo);
+  const [endDate, setEndDate] = useState<Date | undefined>(today);
 
   const handleDateChange = (dates: [Date | null, Date | null]) => {
     const [start, end] = dates;
-    setStartDate(start);
-    setEndDate(end);
+    setStartDate(start || undefined);
+    setEndDate(end || undefined);
     onDateChange(start, end);
   };
 

--- a/src/components/ranking/Chart.tsx
+++ b/src/components/ranking/Chart.tsx
@@ -2,170 +2,18 @@
 
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import DarkUnica from 'highcharts/themes/dark-unica';
+import year_rank from '#/data/year_rank.json';
 import { getTeamRanks } from '@/utils/getTeamRanks';
 
 DarkUnica(Highcharts);
 
 export default function Chart({ title }: { title: string }) {
-  const chartRef = useRef(null);
-  const { yearRank: ktRank, year: ktYear } = getTeamRanks('KT');
-  const [maxNum, setMaxNum] = useState(ktYear.length);
-  console.log('🚀  chartRef:', chartRef);
+  const yearRankJson = year_rank;
+  // const ktRank = getTeamRanks('KT');
 
-  const { yearRank: lgRank, year: lgYear } = getTeamRanks('LG');
-  // console.log('🚀  lgYear:', lgYear);
-  const { yearRank: ssgRank, year: ssgYear } = getTeamRanks('SSG');
-  const { yearRank: ncRank, year: ncYear } = getTeamRanks('NC');
-  const { yearRank: doosanRank, year: doosanYear } = getTeamRanks('두산');
-  const { yearRank: kiaRank, year: kiaYear } = getTeamRanks('KIA');
-  const { yearRank: lotteRank, year: lotteYear } = getTeamRanks('롯데');
-  const { yearRank: samsungRank, year: samsungYear } = getTeamRanks('삼성');
-  const { yearRank: hanwhaRank, year: hanwhaYear } = getTeamRanks('한화');
-  const { yearRank: kiwoomRank, year: kiwoomYear } = getTeamRanks('키움');
-  const { yearRank: hyundaiRank, year: hyundaiYear } = getTeamRanks('현대');
-  const { yearRank: ssangbangwoolRank, year: ssangbangwoolYear } =
-    getTeamRanks('쌍방울');
-
-  // const [options, setOptions] = useState({
-  //   title: {
-  //     text: `${title}`,
-  //     margin: 50,
-  //   },
-  //   subtitle: {
-  //     text: '오른쪽 팀 명을 선택하시면 팀별로 그래프를 확인하실 수 있습니다',
-  //   },
-  //   series: [
-  //     {
-  //       name: 'LG',
-  //       data: lgRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: 'KT',
-  //       data: ktRank,
-  //       visible: true,
-  //     },
-  //     {
-  //       name: 'SSG',
-  //       data: ssgRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: 'NC',
-  //       data: ncRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '두산',
-  //       data: doosanRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: 'KIA',
-  //       data: kiaRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '롯데',
-  //       data: lotteRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '삼성',
-  //       data: samsungRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '한화',
-  //       data: hanwhaRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '키움',
-  //       data: kiwoomRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '현대',
-  //       data: hyundaiRank,
-  //       visible: false,
-  //     },
-  //     {
-  //       name: '쌍방울',
-  //       data: ssangbangwoolRank,
-  //       visible: false,
-  //     },
-  //   ],
-
-  //   xAxis: {
-  //     // categories: yearRankJson.map((item) => item.year),
-  //     categories: '',
-
-  //     labels: {
-  //       rotation: -90,
-  //       align: 'right',
-  //     },
-  //   },
-  //   yAxis: {
-  //     title: {
-  //       text: 'Ranking',
-  //     },
-  //     reversed: true,
-  //     tickInterval: 1,
-  //     min: 0,
-  //     max: 11,
-  //     labels: {
-  //       formatter: function (
-  //         this: Highcharts.AxisLabelsFormatterContextObject,
-  //       ): string | number {
-  //         if (this.value === 0 || this.value === 11) {
-  //           return '';
-  //         }
-  //         return this.value;
-  //       },
-  //     },
-  //   },
-  //   responsive: {
-  //     rules: [
-  //       {
-  //         condition: {
-  //           maxWidth: 500,
-  //         },
-  //         chartOptions: {
-  //           legend: {
-  //             enabled: false,
-  //           },
-  //         },
-  //       },
-  //     ],
-  //   },
-  //   legend: {
-  //     layout: 'vertical',
-  //     align: 'right',
-  //     verticalAlign: 'middle',
-  //   },
-  //   credits: {
-  //     enabled: false,
-  //   },
-  //   chart: {
-  //     height: 560,
-  //     backgroundColor: 'transparent',
-  //   },
-  // });
-
-  // Highcharts.setOptions({
-
-  //   xAxis: {
-  //     categories: Array.from({ length: maxNum }, (v, i) => 2024 - (maxNum - i)),
-  //     labels: {
-  //       rotation: -90,
-  //       align: 'right',
-  //     },
-  //   },
-  // });
-  const options = {
+  const [options] = useState({
     title: {
       text: `${title}`,
       margin: 50,
@@ -176,70 +24,67 @@ export default function Chart({ title }: { title: string }) {
     series: [
       {
         name: 'LG',
-        data: lgRank,
+        data: getTeamRanks('LG'),
         visible: false,
       },
       {
         name: 'KT',
-        data: ktRank,
+        data: getTeamRanks('KT'),
         visible: true,
       },
       {
         name: 'SSG',
-        data: ssgRank,
+        data: getTeamRanks('SSG'),
         visible: false,
       },
       {
         name: 'NC',
-        data: ncRank,
+        data: getTeamRanks('NC'),
         visible: false,
       },
       {
         name: '두산',
-        data: doosanRank,
+        data: getTeamRanks('두산'),
         visible: false,
       },
       {
         name: 'KIA',
-        data: kiaRank,
+        data: getTeamRanks('KIA'),
         visible: false,
       },
       {
         name: '롯데',
-        data: lotteRank,
+        data: getTeamRanks('롯데'),
         visible: false,
       },
       {
         name: '삼성',
-        data: samsungRank,
+        data: getTeamRanks('삼성'),
         visible: false,
       },
       {
         name: '한화',
-        data: hanwhaRank,
+        data: getTeamRanks('한화'),
         visible: false,
       },
       {
         name: '키움',
-        data: kiwoomRank,
+        data: getTeamRanks('키움'),
         visible: false,
       },
       {
         name: '현대',
-        data: hyundaiRank,
+        data: getTeamRanks('현대'),
         visible: false,
       },
       {
         name: '쌍방울',
-        data: ssangbangwoolRank,
+        data: getTeamRanks('쌍방울'),
         visible: false,
       },
     ],
-
     xAxis: {
-      // categories: yearRankJson.map((item) => item.year),
-      categories: Array.from({ length: maxNum }, (v, i) => 2024 - (maxNum - i)),
-
+      categories: yearRankJson.map((item) => item.year),
       labels: {
         rotation: -90,
         align: 'right',
@@ -290,20 +135,7 @@ export default function Chart({ title }: { title: string }) {
       height: 560,
       backgroundColor: 'transparent',
     },
-  };
-
-  useEffect(() => {
-    document
-      .querySelector('.highcharts-legend')
-      ?.addEventListener('click', () => {
-        // console.log(chartRef.current?.chart);
-        const series = chartRef.current.chart.series;
-        const selectedTeam = series.filter((v) => v.visible === true);
-        let selectedteamsData = selectedTeam.map((v) => v.data.length);
-        setMaxNum(() => Math.max(...selectedteamsData));
-        console.log(maxNum);
-      });
-  }, [maxNum]);
+  });
 
   return (
     <div className="max-sm:min-w-[600px]">
@@ -311,7 +143,6 @@ export default function Chart({ title }: { title: string }) {
         highcharts={Highcharts}
         options={options}
         constructorType={'chart'}
-        ref={chartRef}
       />
     </div>
   );

--- a/src/components/ranking/Chart.tsx
+++ b/src/components/ranking/Chart.tsx
@@ -2,18 +2,170 @@
 
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DarkUnica from 'highcharts/themes/dark-unica';
-import year_rank from '#/data/year_rank.json';
 import { getTeamRanks } from '@/utils/getTeamRanks';
 
 DarkUnica(Highcharts);
 
 export default function Chart({ title }: { title: string }) {
-  const yearRankJson = year_rank;
-  // const ktRank = getTeamRanks('KT');
+  const chartRef = useRef(null);
+  const { yearRank: ktRank, year: ktYear } = getTeamRanks('KT');
+  const [maxNum, setMaxNum] = useState(ktYear.length);
+  console.log('🚀  chartRef:', chartRef);
 
-  const [options] = useState({
+  const { yearRank: lgRank, year: lgYear } = getTeamRanks('LG');
+  // console.log('🚀  lgYear:', lgYear);
+  const { yearRank: ssgRank, year: ssgYear } = getTeamRanks('SSG');
+  const { yearRank: ncRank, year: ncYear } = getTeamRanks('NC');
+  const { yearRank: doosanRank, year: doosanYear } = getTeamRanks('두산');
+  const { yearRank: kiaRank, year: kiaYear } = getTeamRanks('KIA');
+  const { yearRank: lotteRank, year: lotteYear } = getTeamRanks('롯데');
+  const { yearRank: samsungRank, year: samsungYear } = getTeamRanks('삼성');
+  const { yearRank: hanwhaRank, year: hanwhaYear } = getTeamRanks('한화');
+  const { yearRank: kiwoomRank, year: kiwoomYear } = getTeamRanks('키움');
+  const { yearRank: hyundaiRank, year: hyundaiYear } = getTeamRanks('현대');
+  const { yearRank: ssangbangwoolRank, year: ssangbangwoolYear } =
+    getTeamRanks('쌍방울');
+
+  // const [options, setOptions] = useState({
+  //   title: {
+  //     text: `${title}`,
+  //     margin: 50,
+  //   },
+  //   subtitle: {
+  //     text: '오른쪽 팀 명을 선택하시면 팀별로 그래프를 확인하실 수 있습니다',
+  //   },
+  //   series: [
+  //     {
+  //       name: 'LG',
+  //       data: lgRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: 'KT',
+  //       data: ktRank,
+  //       visible: true,
+  //     },
+  //     {
+  //       name: 'SSG',
+  //       data: ssgRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: 'NC',
+  //       data: ncRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '두산',
+  //       data: doosanRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: 'KIA',
+  //       data: kiaRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '롯데',
+  //       data: lotteRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '삼성',
+  //       data: samsungRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '한화',
+  //       data: hanwhaRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '키움',
+  //       data: kiwoomRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '현대',
+  //       data: hyundaiRank,
+  //       visible: false,
+  //     },
+  //     {
+  //       name: '쌍방울',
+  //       data: ssangbangwoolRank,
+  //       visible: false,
+  //     },
+  //   ],
+
+  //   xAxis: {
+  //     // categories: yearRankJson.map((item) => item.year),
+  //     categories: '',
+
+  //     labels: {
+  //       rotation: -90,
+  //       align: 'right',
+  //     },
+  //   },
+  //   yAxis: {
+  //     title: {
+  //       text: 'Ranking',
+  //     },
+  //     reversed: true,
+  //     tickInterval: 1,
+  //     min: 0,
+  //     max: 11,
+  //     labels: {
+  //       formatter: function (
+  //         this: Highcharts.AxisLabelsFormatterContextObject,
+  //       ): string | number {
+  //         if (this.value === 0 || this.value === 11) {
+  //           return '';
+  //         }
+  //         return this.value;
+  //       },
+  //     },
+  //   },
+  //   responsive: {
+  //     rules: [
+  //       {
+  //         condition: {
+  //           maxWidth: 500,
+  //         },
+  //         chartOptions: {
+  //           legend: {
+  //             enabled: false,
+  //           },
+  //         },
+  //       },
+  //     ],
+  //   },
+  //   legend: {
+  //     layout: 'vertical',
+  //     align: 'right',
+  //     verticalAlign: 'middle',
+  //   },
+  //   credits: {
+  //     enabled: false,
+  //   },
+  //   chart: {
+  //     height: 560,
+  //     backgroundColor: 'transparent',
+  //   },
+  // });
+
+  // Highcharts.setOptions({
+
+  //   xAxis: {
+  //     categories: Array.from({ length: maxNum }, (v, i) => 2024 - (maxNum - i)),
+  //     labels: {
+  //       rotation: -90,
+  //       align: 'right',
+  //     },
+  //   },
+  // });
+  const options = {
     title: {
       text: `${title}`,
       margin: 50,
@@ -24,67 +176,70 @@ export default function Chart({ title }: { title: string }) {
     series: [
       {
         name: 'LG',
-        data: getTeamRanks('lg'),
+        data: lgRank,
         visible: false,
       },
       {
         name: 'KT',
-        data: getTeamRanks('KT'),
+        data: ktRank,
         visible: true,
       },
       {
         name: 'SSG',
-        data: getTeamRanks('SSG'),
+        data: ssgRank,
         visible: false,
       },
       {
         name: 'NC',
-        data: getTeamRanks('NC'),
+        data: ncRank,
         visible: false,
       },
       {
         name: '두산',
-        data: getTeamRanks('두산'),
+        data: doosanRank,
         visible: false,
       },
       {
         name: 'KIA',
-        data: getTeamRanks('KIA'),
+        data: kiaRank,
         visible: false,
       },
       {
         name: '롯데',
-        data: getTeamRanks('롯데'),
+        data: lotteRank,
         visible: false,
       },
       {
         name: '삼성',
-        data: getTeamRanks('삼성'),
+        data: samsungRank,
         visible: false,
       },
       {
         name: '한화',
-        data: getTeamRanks('한화'),
+        data: hanwhaRank,
         visible: false,
       },
       {
         name: '키움',
-        data: getTeamRanks('키움'),
+        data: kiwoomRank,
         visible: false,
       },
       {
         name: '현대',
-        data: getTeamRanks('현대'),
+        data: hyundaiRank,
         visible: false,
       },
       {
         name: '쌍방울',
-        data: getTeamRanks('쌍방울'),
+        data: ssangbangwoolRank,
         visible: false,
       },
     ],
+
     xAxis: {
-      categories: yearRankJson.map((item) => item.year),
+      // categories: yearRankJson.map((item) => item.year),
+      categories: Array.from({ length: maxNum }, (v, i) => 2024 - (maxNum - i)),
+
       labels: {
         rotation: -90,
         align: 'right',
@@ -135,7 +290,20 @@ export default function Chart({ title }: { title: string }) {
       height: 560,
       backgroundColor: 'transparent',
     },
-  });
+  };
+
+  useEffect(() => {
+    document
+      .querySelector('.highcharts-legend')
+      ?.addEventListener('click', () => {
+        // console.log(chartRef.current?.chart);
+        const series = chartRef.current.chart.series;
+        const selectedTeam = series.filter((v) => v.visible === true);
+        let selectedteamsData = selectedTeam.map((v) => v.data.length);
+        setMaxNum(() => Math.max(...selectedteamsData));
+        console.log(maxNum);
+      });
+  }, [maxNum]);
 
   return (
     <div className="max-sm:min-w-[600px]">
@@ -143,6 +311,7 @@ export default function Chart({ title }: { title: string }) {
         highcharts={Highcharts}
         options={options}
         constructorType={'chart'}
+        ref={chartRef}
       />
     </div>
   );

--- a/src/components/ranking/Chart.tsx
+++ b/src/components/ranking/Chart.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import DarkUnica from 'highcharts/themes/dark-unica';
 import year_rank from '#/data/year_rank.json';
 import { getTeamRanks } from '@/utils/getTeamRanks';
+import { TBaseSeries, TLeagueYearData, TYearData } from '@/types';
 
 DarkUnica(Highcharts);
 
@@ -20,9 +21,9 @@ export default function Chart({
   endDate?: Date | undefined;
   page: string;
 }) {
-  const yearRankJson = year_rank;
+  const yearRankJson: TLeagueYearData = year_rank;
 
-  const yearTeam = [
+  const yearTeam: string[] = [
     'LG',
     'KT',
     'SSG',
@@ -36,7 +37,7 @@ export default function Chart({
     '현대',
     '쌍방울',
   ];
-  const dailyTeam = [
+  const dailyTeam: string[] = [
     'LG',
     'KT',
     'SSG',
@@ -51,37 +52,43 @@ export default function Chart({
 
   const today = new Date();
   const thirtyDaysAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const defaultStartDate = startDate || thirtyDaysAgo;
-  const defaultEndDate = endDate || today;
+  const defaultStartDate: Date = startDate || thirtyDaysAgo;
+  const defaultEndDate: Date = endDate || today;
 
-  const yearArr = yearTeam.map((team) => ({
-    name: team,
-    data: getTeamRanks({ teamName: team, page: 'year' }),
-    visible: team === 'KT',
-  }));
-
-  const dailyArr = dailyTeam.map((team) => ({
-    name: team,
-    data: getTeamRanks({
-      teamName: team,
-      page: 'daily',
-      startDate: defaultStartDate,
-      endDate: defaultEndDate,
+  const yearArr: TBaseSeries[] = yearTeam.map(
+    (team: string): TBaseSeries => ({
+      name: team,
+      data: getTeamRanks({ teamName: team, page: 'year' }),
+      visible: team === 'KT',
     }),
-    visible: team === 'KT',
-  }));
+  );
 
-  const baseSeries = page === 'year' ? yearArr : dailyArr;
+  const dailyArr: TBaseSeries[] = dailyTeam.map(
+    (team: string): TBaseSeries => ({
+      name: team,
+      data: getTeamRanks({
+        teamName: team,
+        page: 'daily',
+        startDate: defaultStartDate,
+        endDate: defaultEndDate,
+      }),
+      visible: team === 'KT',
+    }),
+  );
 
-  const category =
+  const baseSeries: TBaseSeries[] = page === 'year' ? yearArr : dailyArr;
+
+  const category: string[] | number[] =
     page === 'year'
-      ? yearRankJson.map((item) => item.year)
-      : getDateRange(defaultStartDate, defaultEndDate).map((date) => date);
+      ? yearRankJson.map((item: TYearData): number => item.year)
+      : getDateRange(defaultStartDate, defaultEndDate).map(
+          (date: string): string => date,
+        );
 
   function getDateRange(
     startDate: Date | undefined,
     endDate: Date | undefined,
-  ) {
+  ): string[] {
     if (!startDate || !endDate) return [];
 
     const dates = [];

--- a/src/components/ranking/Chart.tsx
+++ b/src/components/ranking/Chart.tsx
@@ -9,82 +9,103 @@ import { getTeamRanks } from '@/utils/getTeamRanks';
 
 DarkUnica(Highcharts);
 
-export default function Chart({ title }: { title: string }) {
+export default function Chart({
+  title,
+  startDate,
+  endDate,
+  page,
+}: {
+  title: string;
+  startDate?: Date | undefined;
+  endDate?: Date | undefined;
+  page: string;
+}) {
   const yearRankJson = year_rank;
-  // const ktRank = getTeamRanks('KT');
+
+  const yearTeam = [
+    'LG',
+    'KT',
+    'SSG',
+    'NC',
+    '두산',
+    'KIA',
+    '롯데',
+    '삼성',
+    '한화',
+    '키움',
+    '현대',
+    '쌍방울',
+  ];
+  const dailyTeam = [
+    'LG',
+    'KT',
+    'SSG',
+    'NC',
+    '두산',
+    'KIA',
+    '롯데',
+    '삼성',
+    '한화',
+    '키움',
+  ];
+
+  const today = new Date();
+  const thirtyDaysAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const defaultStartDate = startDate || thirtyDaysAgo;
+  const defaultEndDate = endDate || today;
+
+  const yearArr = yearTeam.map((team) => ({
+    name: team,
+    data: getTeamRanks({ teamName: team, page: 'year' }),
+    visible: team === 'KT',
+  }));
+
+  const dailyArr = dailyTeam.map((team) => ({
+    name: team,
+    data: getTeamRanks({
+      teamName: team,
+      page: 'daily',
+      startDate: defaultStartDate,
+      endDate: defaultEndDate,
+    }),
+    visible: team === 'KT',
+  }));
+
+  const baseSeries = page === 'year' ? yearArr : dailyArr;
+
+  const category =
+    page === 'year'
+      ? yearRankJson.map((item) => item.year)
+      : getDateRange(defaultStartDate, defaultEndDate).map((date) => date);
+
+  function getDateRange(
+    startDate: Date | undefined,
+    endDate: Date | undefined,
+  ) {
+    if (!startDate || !endDate) return [];
+
+    const dates = [];
+    const currentDate = new Date(startDate);
+
+    while (currentDate <= new Date(endDate)) {
+      dates.push(currentDate.toISOString().slice(5, 10));
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return dates;
+  }
 
   const [options] = useState({
     title: {
-      text: `${title}`,
+      text: title,
       margin: 50,
     },
     subtitle: {
       text: '오른쪽 팀 명을 선택하시면 팀별로 그래프를 확인하실 수 있습니다',
     },
-    series: [
-      {
-        name: 'LG',
-        data: getTeamRanks('LG'),
-        visible: false,
-      },
-      {
-        name: 'KT',
-        data: getTeamRanks('KT'),
-        visible: true,
-      },
-      {
-        name: 'SSG',
-        data: getTeamRanks('SSG'),
-        visible: false,
-      },
-      {
-        name: 'NC',
-        data: getTeamRanks('NC'),
-        visible: false,
-      },
-      {
-        name: '두산',
-        data: getTeamRanks('두산'),
-        visible: false,
-      },
-      {
-        name: 'KIA',
-        data: getTeamRanks('KIA'),
-        visible: false,
-      },
-      {
-        name: '롯데',
-        data: getTeamRanks('롯데'),
-        visible: false,
-      },
-      {
-        name: '삼성',
-        data: getTeamRanks('삼성'),
-        visible: false,
-      },
-      {
-        name: '한화',
-        data: getTeamRanks('한화'),
-        visible: false,
-      },
-      {
-        name: '키움',
-        data: getTeamRanks('키움'),
-        visible: false,
-      },
-      {
-        name: '현대',
-        data: getTeamRanks('현대'),
-        visible: false,
-      },
-      {
-        name: '쌍방울',
-        data: getTeamRanks('쌍방울'),
-        visible: false,
-      },
-    ],
+    series: baseSeries,
     xAxis: {
-      categories: yearRankJson.map((item) => item.year),
+      categories: category,
       labels: {
         rotation: -90,
         align: 'right',

--- a/src/components/ranking/Chart.tsx
+++ b/src/components/ranking/Chart.tsx
@@ -4,10 +4,15 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import { useState } from 'react';
 import DarkUnica from 'highcharts/themes/dark-unica';
+import year_rank from '#/data/year_rank.json';
+import { getTeamRanks } from '@/utils/getTeamRanks';
 
 DarkUnica(Highcharts);
 
 export default function Chart({ title }: { title: string }) {
+  const yearRankJson = year_rank;
+  // const ktRank = getTeamRanks('KT');
+
   const [options] = useState({
     title: {
       text: `${title}`,
@@ -19,59 +24,71 @@ export default function Chart({ title }: { title: string }) {
     series: [
       {
         name: 'LG',
-        data: [3, 1, 3, 2, 1, 3, 2, 1, 2],
+        data: getTeamRanks('lg'),
         visible: false,
       },
       {
         name: 'KT',
-        data: [1, 3, 1, 4, 2, 1, 4, 2, 7],
+        data: getTeamRanks('KT'),
         visible: true,
       },
       {
         name: 'SSG',
-        data: [10, 2, 6, 1, 3, 6, 1, 3, 5],
+        data: getTeamRanks('SSG'),
         visible: false,
       },
       {
         name: 'NC',
-        data: [2, 9, 7, 6, 4, 7, 6, 4, 6],
+        data: getTeamRanks('NC'),
         visible: false,
       },
       {
         name: '두산',
-        data: [8, 8, 4, 9, 5, 4, 9, 5, 4],
+        data: getTeamRanks('두산'),
         visible: false,
       },
       {
         name: 'KIA',
-        data: [7, 10, 9, 5, 6, 9, 5, 6, 1],
+        data: getTeamRanks('KIA'),
         visible: false,
       },
       {
         name: '롯데',
-        data: [9, 4, 8, 8, 7, 8, 8, 7, 8],
+        data: getTeamRanks('롯데'),
         visible: false,
       },
       {
         name: '삼성',
-        data: [6, 5, 2, 7, 8, 2, 7, 8, 3],
+        data: getTeamRanks('삼성'),
         visible: false,
       },
       {
         name: '한화',
-        data: [4, 6, 10, 10, 9, 10, 10, 9, 9],
+        data: getTeamRanks('한화'),
         visible: false,
       },
       {
         name: '키움',
-        data: [5, 7, 5, 3, 10, 5, 3, 10, 10],
+        data: getTeamRanks('키움'),
+        visible: false,
+      },
+      {
+        name: '현대',
+        data: getTeamRanks('현대'),
+        visible: false,
+      },
+      {
+        name: '쌍방울',
+        data: getTeamRanks('쌍방울'),
         visible: false,
       },
     ],
     xAxis: {
-      categories: [
-        2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024,
-      ],
+      categories: yearRankJson.map((item) => item.year),
+      labels: {
+        rotation: -90,
+        align: 'right',
+      },
     },
     yAxis: {
       title: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -126,7 +126,20 @@ type TYearData = {
   data: TRanking[];
 };
 
-type TLeagueData = TYearData[];
+type TDailyData = {
+  day: number;
+  data: TRanking[];
+};
+
+type TLeagueYearData = TYearData[];
+
+type TLeagueDailyData = TDailyData[];
+
+type TBaseSeries = {
+  name: string;
+  data: (number | null)[];
+  visible: boolean;
+};
 
 export {
   TResultPositionProps,
@@ -142,5 +155,10 @@ export {
   TTeamRecord,
   TGameInfo,
   TWinLossData,
-  TLeagueData,
+  TRanking,
+  TYearData,
+  TDailyData,
+  TLeagueYearData,
+  TLeagueDailyData,
+  TBaseSeries,
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -116,6 +116,18 @@ type TWinLossData = {
   recent: RecentStats;
 };
 
+type TRanking = {
+  rank: number;
+  team: string;
+};
+
+type TYearData = {
+  year: number;
+  data: TRanking[];
+};
+
+type TLeagueData = TYearData[];
+
 export {
   TResultPositionProps,
   TQuestionHandlerProps,
@@ -130,4 +142,5 @@ export {
   TTeamRecord,
   TGameInfo,
   TWinLossData,
+  TLeagueData,
 };

--- a/src/utils/getTeamRanks.ts
+++ b/src/utils/getTeamRanks.ts
@@ -1,24 +1,15 @@
 import year_rank from '#/data/year_rank.json';
+import { TLeagueData } from '@/types';
 
 export const getTeamRanks = (teamName: string) => {
-  const yearRankJson = year_rank;
+  const yearRankJson: TLeagueData = year_rank;
 
-  const yearRank: any[] = [];
-  const year: any[] = [];
+  const yearRank: (number | null)[] = [];
 
-  // yearRankJson.forEach((item) => {
-  //   const teamData = item.data.find((v) => v.team === teamName);
-  //   yearRank.push(teamData ? teamData.rank : 'null');
-  // });
   yearRankJson.forEach((item) => {
     const teamData = item.data.find((v) => v.team === teamName);
-    if (teamData) {
-      yearRank.push(teamData.rank);
-      year.push(item.year);
-    }
+    yearRank.push(teamData ? teamData.rank : null);
   });
-  // yearRank.push(teamData ? teamData.rank : 'null');
 
-  return { yearRank, year };
-  // return yearRank;
+  return yearRank;
 };

--- a/src/utils/getTeamRanks.ts
+++ b/src/utils/getTeamRanks.ts
@@ -4,11 +4,21 @@ export const getTeamRanks = (teamName: string) => {
   const yearRankJson = year_rank;
 
   const yearRank: any[] = [];
+  const year: any[] = [];
 
+  // yearRankJson.forEach((item) => {
+  //   const teamData = item.data.find((v) => v.team === teamName);
+  //   yearRank.push(teamData ? teamData.rank : 'null');
+  // });
   yearRankJson.forEach((item) => {
     const teamData = item.data.find((v) => v.team === teamName);
-    yearRank.push(teamData ? teamData.rank : 'null');
+    if (teamData) {
+      yearRank.push(teamData.rank);
+      year.push(item.year);
+    }
   });
+  // yearRank.push(teamData ? teamData.rank : 'null');
 
-  return yearRank;
+  return { yearRank, year };
+  // return yearRank;
 };

--- a/src/utils/getTeamRanks.ts
+++ b/src/utils/getTeamRanks.ts
@@ -1,15 +1,56 @@
 import year_rank from '#/data/year_rank.json';
+import daily_rank from '#/data/daily_rank.json';
 import { TLeagueData } from '@/types';
 
-export const getTeamRanks = (teamName: string) => {
+export const getTeamRanks = ({
+  teamName,
+  page,
+  startDate,
+  endDate,
+}: {
+  teamName: string;
+  page: string;
+  startDate?: Date | undefined;
+  endDate?: Date | undefined;
+}) => {
+  const formatDate = (dateString: string | undefined) => {
+    if (!dateString) return undefined;
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return Number(`${year}${month}${day}`);
+  };
+
   const yearRankJson: TLeagueData = year_rank;
+  const dailyRankJson = daily_rank;
+  const baseJson = page === 'year' ? yearRankJson : dailyRankJson;
 
   const yearRank: (number | null)[] = [];
 
-  yearRankJson.forEach((item) => {
-    const teamData = item.data.find((v) => v.team === teamName);
-    yearRank.push(teamData ? teamData.rank : null);
-  });
+  const formatStartDate = formatDate(startDate?.toISOString());
+  const formatEndDate = formatDate(endDate?.toISOString());
+
+  if (page === 'daily') {
+    const filteredDailyRank = dailyRankJson.filter((item) => {
+      const itemDate = new Date(item.day);
+
+      return (
+        (!formatStartDate || itemDate >= formatStartDate) &&
+        (!formatEndDate || itemDate <= formatEndDate)
+      );
+    });
+
+    filteredDailyRank.forEach((item) => {
+      const teamData = item.data.find((v) => v.team === teamName);
+      yearRank.push(teamData ? teamData.rank : null);
+    });
+  } else {
+    baseJson.forEach((item) => {
+      const teamData = item.data.find((v) => v.team === teamName);
+      yearRank.push(teamData ? teamData.rank : null);
+    });
+  }
 
   return yearRank;
 };

--- a/src/utils/getTeamRanks.ts
+++ b/src/utils/getTeamRanks.ts
@@ -1,0 +1,14 @@
+import year_rank from '#/data/year_rank.json';
+
+export const getTeamRanks = (teamName: string) => {
+  const yearRankJson = year_rank;
+
+  const yearRank: any[] = [];
+
+  yearRankJson.forEach((item) => {
+    const teamData = item.data.find((v) => v.team === teamName);
+    yearRank.push(teamData ? teamData.rank : 'null');
+  });
+
+  return yearRank;
+};


### PR DESCRIPTION
-  년도별 데이터 그래프에 적용
-  년도별 타입 적용
-  /ai 데이터 캐싱 해결
-  /ai 페이지 경기 없을 경우 예외 처리
-  일자별 데이터 그래프 적용
-  날짜 선택 시 날짜에 맞게 그래프 적용
-  일자별 타입 적용